### PR TITLE
Parse Gemfile for brakeman version if 'gemfile' version is selected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ruby:2.7-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git
+
+# hadolint ignore=DL3018
+RUN apk add --update --no-cache build-base git grep
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 ### `brakeman_version`
 
 Optional. Set brakeman version. 
-By default, the latest version is installed.
+* empty or omit: install latest version
+* `gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* version (e.g. `4.8.2`): install said version
 
 ### `brakeman_flags`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,29 @@ version() {
 cd "$GITHUB_WORKSPACE"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-gem install -N brakeman $(version $INPUT_BRAKEMAN_VERSION)
+# if 'gemfile' brakeman version selected
+if [[ $INPUT_BRAKEMAN_VERSION = "gemfile" ]]; then
+  # if Gemfile.lock is here
+  if [[ -f 'Gemfile.lock' ]]; then
+    # grep for brakeman version
+    BRAKEMAN_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP '^\s{4}brakeman\s\(\K.*(?=\))'`
+
+    # if brakeman version found, then pass it to the gem install
+    # left it empty otherwise, so no version will be passed
+    if [[ -n "$BRAKEMAN_GEMFILE_VERSION" ]]; then
+      BRAKEMAN_VERSION=$BRAKEMAN_GEMFILE_VERSION
+      else
+        printf "Cannot get the brakeman's version from Gemfile.lock. The latest version will be installed."
+    fi
+    else
+      printf 'Gemfile.lock not found. The latest version will be installed.'
+  fi
+  else
+    # set desired brakeman version
+    BRAKEMAN_VERSION=$INPUT_BRAKEMAN_VERSION
+fi
+
+gem install -N brakeman $(version $BRAKEMAN_VERSION)
 
 brakeman --quiet --format tabs ${INPUT_BRAKEMAN_FLAGS} \
   | reviewdog -f=brakeman \


### PR DESCRIPTION
- Add ability to parse `Gemfile.lock` for reek version, if `gemfile` reek version is selected. Install latest bundler or fixed version otherwise.
- Add `grep` to Dockerfile in order to use GNU grep with PCRE support.
- Update readme.