### PR TITLE
Fail if Brakeman fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -o pipefail
+
 version() {
   if [ -n "$1" ]; then
     echo "-v $1"


### PR DESCRIPTION
Fix for #27

Consider it an error if either `brakeman` or `reviewdog` return non-zero