### PR TITLE
Pass INPUT_BRAKEMAN_FLAGS as separated strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           brakeman_version: 'gemfile'
+          brakeman_flags: '--force'
       - run: |
           test "$(bundle exec brakeman --version)" == "brakeman 5.1.2"

--- a/script.sh
+++ b/script.sh
@@ -38,7 +38,9 @@ echo '::endgroup::'
 
 echo '::group:: Running brakeman with reviewdog 🐶 ...'
 BRAKEMAN_REPORT_FILE="$TEMP_PATH"/brakeman_report
-brakeman --quiet --format tabs "${INPUT_BRAKEMAN_FLAGS}" --output "$BRAKEMAN_REPORT_FILE"
+
+# shellcheck disable=SC2086
+brakeman --quiet --format tabs ${INPUT_BRAKEMAN_FLAGS} --output "$BRAKEMAN_REPORT_FILE"
 reviewdog < "$BRAKEMAN_REPORT_FILE" \
   -f=brakeman \
   -name="${INPUT_TOOL_NAME}" \


### PR DESCRIPTION
This pull request fixes https://github.com/reviewdog/action-brakeman/issues/30 by the same approach done in https://github.com/reviewdog/action-rubocop/pull/18.