### PR TITLE
Fix GitHub Actions not to use brakeman's exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional. Set brakeman version.
 
 ### `brakeman_flags`
 
-Optional. Brakeman flags. (brakeman --quiet --format tabs `<brakeman_flags>`)
+Optional. Brakeman flags. (brakeman --quiet --format tabs --no-exit-on-warn --no-exit-on-error `<brakeman_flags>`)
 
 ### `tool_name`
 

--- a/script.sh
+++ b/script.sh
@@ -46,7 +46,7 @@ echo '::group:: Running brakeman with reviewdog 🐶 ...'
 BRAKEMAN_REPORT_FILE="$TEMP_PATH"/brakeman_report
 
 # shellcheck disable=SC2086
-brakeman --quiet --format tabs ${INPUT_BRAKEMAN_FLAGS} --output "$BRAKEMAN_REPORT_FILE"
+brakeman --quiet --format tabs --no-exit-on-warn --no-exit-on-error ${INPUT_BRAKEMAN_FLAGS} --output "$BRAKEMAN_REPORT_FILE"
 reviewdog < "$BRAKEMAN_REPORT_FILE" \
   -f=brakeman \
   -name="${INPUT_TOOL_NAME}" \


### PR DESCRIPTION
#38 

Actions always failed if the target has security vulnerabilities in spite of the fail_on_error value.
That's because Brakeman and reviewdog command executions are separated.