### PR TITLE
Bump reviewdog to 0.17.1 for new github-pr-annotations reporter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:
-        REVIEWDOG_VERSION: v0.15.0
+        REVIEWDOG_VERSION: v0.17.1
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_BRAKEMAN_VERSION: ${{ inputs.brakeman_version }}
         INPUT_BRAKEMAN_FLAGS: ${{ inputs.brakeman_flags }}


### PR DESCRIPTION
This bumps the reviewdog version from 0.15.0 to 0.17.1 as while it's been a few releases behind, it would be helpful to have access to the [new github-pr-annotations reporter from the 0.17.0 release](https://github.com/reviewdog/reviewdog/pull/1623) which helps [resolve a longstanding reviewdog issue](https://github.com/reviewdog/reviewdog/issues/403).