### PR TITLE
Bump reviewdog version to v0.17.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:
-        REVIEWDOG_VERSION: v0.17.1
+        REVIEWDOG_VERSION: v0.17.3
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_BRAKEMAN_VERSION: ${{ inputs.brakeman_version }}
         INPUT_BRAKEMAN_FLAGS: ${{ inputs.brakeman_flags }}


### PR DESCRIPTION
## Abstruct
Update reviewdog version to 0.17.3.
To avoid API error from GitHub when PR has a lot of diff.

## Summary
Notable change:
- https://github.com/reviewdog/reviewdog/pull/1697

All changes:
- https://github.com/reviewdog/reviewdog/releases/tag/v0.17.2
- https://github.com/reviewdog/reviewdog/releases/tag/v0.17.3
- https://github.com/reviewdog/reviewdog/compare/v0.17.1...v0.17.3